### PR TITLE
Atualização do nome do contexto e criação do RepositorioBase

### DIFF
--- a/LabSysCloud.Data/Context/LabSysCloudContext.cs
+++ b/LabSysCloud.Data/Context/LabSysCloudContext.cs
@@ -9,9 +9,9 @@ using LabSysCloud.Data.Mapping;
 
 namespace LabSysCloud.Data.Context
 {
-    public class AppContext : DbContext
+    public class LabSysCloudContext : DbContext
     {
-        public AppContext(DbContextOptions<AppContext> options) : base(options)
+        public LabSysCloudContext(DbContextOptions<LabSysCloudContext> options) : base(options)
         {
 
         }

--- a/LabSysCloud.Data/Repositories/RepositorioBase.cs
+++ b/LabSysCloud.Data/Repositories/RepositorioBase.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using LabSysCloud.Data.Context;
+using LabSysCloud.Domain.Entities;
+using LabSysCloud.Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace LabSysCloud.Data.Repositories
+{
+    public class RepositorioBase<TEntity> : IRepositorioBase<TEntity> where TEntity : EntidadeBase
+    {
+        protected readonly LabSysCloudContext _context;
+
+        public RepositorioBase(LabSysCloudContext context)
+        {
+            _context = context;
+        }
+
+        public void Adicionar(TEntity obj)
+        {
+            _context.Set<TEntity>().Add(obj);
+            _context.SaveChanges();
+        }
+
+        public void Atualizar(TEntity obj)
+        {
+            _context.Entry(obj).State = EntityState.Modified;
+            _context.SaveChanges();
+        }
+
+        public void Deletar(long id)
+        {
+            _context.Set<TEntity>().Remove(BuscarPorId(id));
+            _context.SaveChanges();
+        }
+
+        public TEntity BuscarPorId(long id) => _context.Set<TEntity>().Find(id);
+        public IList<TEntity> BuscarTodos() => _context.Set<TEntity>().ToList();
+
+    }
+}

--- a/LabSysCloud.Domain/Interfaces/IRepositorioBase.cs
+++ b/LabSysCloud.Domain/Interfaces/IRepositorioBase.cs
@@ -11,7 +11,7 @@ namespace LabSysCloud.Domain.Interfaces
         void Adicionar(TEntity obj);
         void Atualizar(TEntity obj);
         void Deletar(long id);
-        IList<TEntity> ListarTodos();
-        TEntity ListarPorId(long id);
+        IList<TEntity> BuscarTodos();
+        TEntity BuscarPorId(long id);
     }
 }


### PR DESCRIPTION
Foi necessário a alteração do nome da classe de contexto por estar em abiguidade com o AppContext do EF.